### PR TITLE
Update postgres to 0.11.3

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,2 @@
-export { Client } from "https://deno.land/x/postgres@v0.11.2/mod.ts";
-export type { ConnectionOptions } from "https://deno.land/x/postgres@v0.11.2/mod.ts";
+export { Client } from "https://deno.land/x/postgres@v0.11.3/mod.ts";
+export type { ConnectionOptions } from "https://deno.land/x/postgres@v0.11.3/mod.ts";


### PR DESCRIPTION
Postgres 0.11.2 has an issue with non-TLS connections in deno >=1.10, so this unlocks the upgrade for me.