### PR TITLE
Add binary data type (aka ByteArray, BYTEA)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export enum DataType {
   Interval = "INTERVAL",
   Time = "TIME",
   UUID = "UUID",
+  ByteArray = "BYTEA",
   HStore = "HSTORE",
   Box = "BOX",
   Line = "LINE",


### PR DESCRIPTION
Seemed to work¹ locally for me when I did `{ type: "BYTEA" as DataType }`. Not sure if more testing is needed here.

¹Faithfully stored and retrieved a `Uint8Array` including bytes close to 0 and close to 255.