### PR TITLE
Fix delete()

### DIFF
--- a/src/where.ts
+++ b/src/where.ts
@@ -120,7 +120,7 @@ export class QueryWhere<T extends Record<string, unknown> = QueryCondition> {
   async delete() {
     const make = this.make();
     await this.client.query<T>(
-      `DELETE FROM ${unsketchify(this.table)} ${this.make()}`,
+      `DELETE FROM ${unsketchify(this.table)} ${this.make().sql}`,
       make.params
     );
     return this;


### PR DESCRIPTION
`.make()` returns an object, using it in a template string produces `"[object Object]"`, which is not intended. Accessing `.sql` instead.